### PR TITLE
Add local repo positional argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+[NEW] "local" `repo` positional argument option is now valid bypassing remote validation.
+
 # 1.0.0
 
 [NEW] Make the Auditree Harvest tool public.

--- a/harvest/__init__.py
+++ b/harvest/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """The Auditree file collating and reporting tool."""
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/harvest/cli.py
+++ b/harvest/cli.py
@@ -42,14 +42,15 @@ class _CoreHarvestCommand(Command):
             'repo',
             help=(
                 'the URL to the repository containing files to be processed '
-                'by harvest, as an example https://github.com/my-org/my-repo'
+                'by harvest, as an example: https://github.com/my-org/my-repo '
+                'or: local - if working exclusively with a local git repo'
             )
         )
         self.add_argument(
             '--repo-path',
             help=(
                 'the operating system location of a local git repository - '
-                'if not provided, repo will be cloned to $TMPDIR/harvest'
+                'if not provided, repo path is assumed to be $TMPDIR/harvest'
             ),
             metavar='~/path/git-repo',
             default=None
@@ -65,6 +66,11 @@ class _CoreHarvestCommand(Command):
         )
 
     def _validate_arguments(self, args):
+        if args.repo == 'local':
+            if not args.repo_path:
+                return 'ERROR: --repo-path expected for "local" mode'
+            args.repo = 'https://local/local/local'
+            args.no_validate = False
         parsed = urlparse(args.repo)
         if not (parsed.scheme and parsed.hostname and parsed.path):
             return (

--- a/test/test_cli_collate.py
+++ b/test/test_cli_collate.py
@@ -210,3 +210,26 @@ class TestHarvestCLICollate(unittest.TestCase):
         )
         mock_read.assert_not_called()
         mock_write.assert_not_called()
+
+    @patch('harvest.collator.Collator.write')
+    @patch('harvest.collator.Collator.read')
+    def test_collate_local(self, mock_read, mock_write):
+        """Ensures collate sub-command works when 'local' repo provided."""
+        mock_read.return_value = ['commit-foo']
+        self.harvest.run(
+            [
+                'collate',
+                'local',
+                'my/path/baz.json',
+                '--repo-path',
+                'os/repo/path'
+            ]
+        )
+        today = datetime.today()
+
+        mock_read.assert_called_once_with(
+            'my/path/baz.json',
+            datetime(today.year, today.month, today.day),
+            datetime(today.year, today.month, today.day)
+        )
+        mock_write.assert_called_once_with('my/path/baz.json', ['commit-foo'])


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add local repo positional argument

## Why

So validation with a remote repository is bypassed

## How

Allow `local` as a valid value for the `repo` positional argument provided that it is accompanied by the `--repo-path` argument.

## Test

- New unit test works
- All previous unit tests work
- Original functionality preserved.  All tests work as expected.
- When supplying `local` and `--repo-path` the local git repo defined by `--repo-path` is used
- Supplying `local` without a `--repo-path` produces an error
- When supplying a remote repo and `--repo-path` the local git repo defined by `--repo-path` is used after being refreshed

## Context

Closes #14 
