### PR TITLE
Remove creds requirement when in local repo mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- [FIXED] Credentials are no longer expected when running in local repo mode.
+
 # 1.1.0
 
 - [NEW] "local" `repo` positional argument option is now valid bypassing remote validation.

--- a/harvest/__init__.py
+++ b/harvest/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """The Auditree file collating and reporting tool."""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/harvest/cli.py
+++ b/harvest/cli.py
@@ -68,9 +68,10 @@ class _CoreHarvestCommand(Command):
     def _validate_arguments(self, args):
         if args.repo == 'local':
             if not args.repo_path:
-                return 'ERROR: --repo-path expected for "local" mode'
+                return 'ERROR: --repo-path required when using local repo mode'
             args.repo = 'https://local/local/local'
             args.no_validate = False
+            args.creds = None
         parsed = urlparse(args.repo)
         if not (parsed.scheme and parsed.hostname and parsed.path):
             return (
@@ -129,7 +130,7 @@ class Collate(_CoreHarvestCommand):
     def _run(self, args):
         collator = Collator(
             args.repo,
-            Config(args.creds),
+            Config(args.creds) if args.creds else None,
             'master',
             args.repo_path,
             args.no_validate
@@ -187,7 +188,7 @@ class Report(_CoreHarvestCommand):
     def _run(self, args):
         reporter = self.report(
             args.repo,
-            Config(args.creds),
+            Config(args.creds) if args.creds else None,
             'master',
             args.repo_path,
             self.template_dir,


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Creds are no longer required when running in local repo mode.

## Why

Local repo mode doesn't need creds because the repo is local and no validation is being performed so Harvest shouldn't expect a credentials file when running in this mode.

## How

- If running in local repo mode, don't create a credentials.Config object.

## Test

- Collate and Report commands:
   - Works when running in local repo mode.  Confirmed that no creds are expected.
   - Works when running in remote repo mode but using a `--repo-path`.  Confirmed creds are expected and used.
   - Works when running in remote repo mode without `--repo-path`.  Confirmed creds are expected and used.

## Context

Fixes #17 
