### PR TITLE
Fix corrupt git repo bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         files: "^(harvest|test)"
         stages: [commit]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
     -   id: flake8
         args: [

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,16 @@
-# 1.1.1 (2020-09-03)
+# [1.2.0](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.2.0)
+
+- [FIXED] Invalid Git repo error is now handled by a refresh of the local Git repo.
+- [ADDED] Local path to the Git repo was added as a Collator property.
+
+# [1.1.1](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.1.1)
 
 - [FIXED] Credentials are no longer expected when running in local repo mode.
 
-# 1.1.0 (2020-09-02)
+# [1.1.0](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.1.0)
 
 - [ADDED] "local" `repo` positional argument option is now valid bypassing remote validation.
 
-# 1.0.0 (2020-07-27)
+# [1.0.0](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.0.0)
 
 - [ADDED] Made the Auditree Harvest tool public.

--- a/harvest/__init__.py
+++ b/harvest/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """The Auditree file collating and reporting tool."""
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'

--- a/test/test_collator.py
+++ b/test/test_collator.py
@@ -17,6 +17,7 @@
 import tempfile
 import unittest
 from datetime import datetime
+from pathlib import PurePath
 from unittest.mock import MagicMock, call, create_autospec, mock_open, patch
 
 from git import Commit, Remote, Repo
@@ -57,6 +58,10 @@ class TestCollator(unittest.TestCase):
         self.assertEqual(collator.branch, 'master')
         self.assertIsNone(collator.repo_path)
         self.assertIsNone(collator.git_repo)
+        tmpdir = PurePath(tempfile.gettempdir())
+        self.assertEqual(
+            collator.local_path, str(tmpdir.joinpath('harvest', 'foo', 'bar'))
+        )
 
     def test_constructor_with_repo_path(self):
         """Ensures collate object is constructed as expected."""
@@ -69,6 +74,7 @@ class TestCollator(unittest.TestCase):
         self.assertEqual(collator.branch, 'master')
         self.assertEqual(collator.repo_path, 'my/repo/path')
         self.assertIsNone(collator.git_repo)
+        self.assertEqual(collator.local_path, 'my/repo/path')
 
     def test_read_date_comparison(self):
         """Ensures read returns commits when date logic triggers completion."""


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix corrupt git repo bug.

## Why

It's a better user experience to handle a corrupted local Git repo by removing the corrupted directory and (re)cloning the repo.

## How

- If the repo exists and an attempt to checkout the repo occurs, check for `git.exc.InvalidGitRepositoryError`.  If encountered then remove the current repo directory and (re)clone the Git repo.

## Test

- Current working functionality is preserved
- If a repo is corrupted it is re-cloned

## Context

Fixes #10 
