### PR TITLE
Human readable dates and multiple file path support in the collate command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# [1.3.0](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.3.0)
+
+- [ADDED] Added option to use the date format YYYY-MM-DD in addition to YYYYMMDD when collating files.
+- [ADDED] Made it possible to collate multiple files during a single run.
+
 # [1.2.1](https://github.com/ComplianceAsCode/auditree-harvest/releases/tag/v1.2.1)
 
 - [CHANGED] Removed yapf in favour of black as code formatter.

--- a/harvest/__init__.py
+++ b/harvest/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The Auditree file collating and reporting tool."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/harvest/cli.py
+++ b/harvest/cli.py
@@ -88,6 +88,7 @@ class Collate(_CoreHarvestCommand):
                 "the relative path to a file in a git repository "
                 "that you wish to retrieve"
             ),
+            nargs="+",
         )
         self.add_argument(
             "--end",
@@ -137,12 +138,12 @@ class Collate(_CoreHarvestCommand):
             args.repo_path,
             args.no_validate,
         )
-        try:
-            collator.write(
-                args.filepath, collator.read(args.filepath, args.start, args.end)
-            )
-        except ValueError as e:
-            self.err(f"ERROR: {str(e)}")
+
+        for file in args.filepath:
+            try:
+                collator.write(file, collator.read(file, args.start, args.end))
+            except ValueError as e:
+                self.err(f"ERROR: {str(e)}")
 
 
 class Report(_CoreHarvestCommand):

--- a/harvest/cli.py
+++ b/harvest/cli.py
@@ -95,7 +95,7 @@ class Collate(_CoreHarvestCommand):
                 "the end of date range for the file you wish to retrieve - "
                 "defaults to the current date"
             ),
-            metavar="YYYYMMDD",
+            metavar="YYYY-MM-DD or YYYYMMDD",
             default=False,
         )
         self.add_argument(
@@ -104,17 +104,23 @@ class Collate(_CoreHarvestCommand):
                 "the start of date range for the file you wish to retrieve - "
                 "defaults to same value as the end of date range"
             ),
-            metavar="YYYYMMDD",
+            metavar="YYYY-MM-DD or YYYYMMDD",
             default=False,
         )
 
     def _validate_arguments(self, args):
         if not args.end:
-            args.end = datetime.today().strftime("%Y%m%d")
+            args.end = datetime.today().strftime("%Y-%m-%d")
         if not args.start:
             args.start = args.end
-        args.start = datetime.strptime(args.start, "%Y%m%d")
-        args.end = datetime.strptime(args.end, "%Y%m%d")
+        if "-" in args.start:
+            args.start = datetime.strptime(args.start, "%Y-%m-%d")
+        else:
+            args.start = datetime.strptime(args.start, "%Y%m%d")
+        if "-" in args.end:
+            args.end = datetime.strptime(args.end, "%Y-%m-%d")
+        else:
+            args.end = datetime.strptime(args.end, "%Y%m%d")
         if args.start > datetime.today():
             return "ERROR: start date cannot be in the future"
         if args.start > args.end:

--- a/test/test_cli_collate.py
+++ b/test/test_cli_collate.py
@@ -76,6 +76,32 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "https://github.com/foo/bar",
                 "my/path/baz.json",
                 "--start",
+                "2019-10-20",
+            ]
+        )
+        today = datetime.today()
+        mock_read.assert_called_once_with(
+            "my/path/baz.json",
+            datetime(2019, 10, 20),
+            datetime(today.year, today.month, today.day),
+        )
+        mock_write.assert_called_once_with(
+            "my/path/baz.json", ["commit-foo", "commit-bar", "commit-baz"]
+        )
+
+    @patch("harvest.collator.Collator.write")
+    @patch("harvest.collator.Collator.read")
+    def test_collate_start_date_only_without_date_seperator(
+        self, mock_read, mock_write
+    ):
+        """Ensures collate sub-command works when only start date provided."""
+        mock_read.return_value = ["commit-foo", "commit-bar", "commit-baz"]
+        self.harvest.run(
+            [
+                "collate",
+                "https://github.com/foo/bar",
+                "my/path/baz.json",
+                "--start",
                 "20191020",
             ]
         )
@@ -92,6 +118,27 @@ class TestHarvestCLICollate(unittest.TestCase):
     @patch("harvest.collator.Collator.write")
     @patch("harvest.collator.Collator.read")
     def test_collate_end_date_only(self, mock_read, mock_write):
+        """Ensures collate sub-command works when only end date provided."""
+        mock_read.return_value = ["commit-foo", "commit-bar", "commit-baz"]
+        self.harvest.run(
+            [
+                "collate",
+                "https://github.com/foo/bar",
+                "my/path/baz.json",
+                "--end",
+                "2019-10-20",
+            ]
+        )
+        mock_read.assert_called_once_with(
+            "my/path/baz.json", datetime(2019, 10, 20), datetime(2019, 10, 20)
+        )
+        mock_write.assert_called_once_with(
+            "my/path/baz.json", ["commit-foo", "commit-bar", "commit-baz"]
+        )
+
+    @patch("harvest.collator.Collator.write")
+    @patch("harvest.collator.Collator.read")
+    def test_collate_end_date_only_no_date_seperators(self, mock_read, mock_write):
         """Ensures collate sub-command works when only end date provided."""
         mock_read.return_value = ["commit-foo", "commit-bar", "commit-baz"]
         self.harvest.run(
@@ -121,9 +168,9 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "https://github.com/foo/bar",
                 "my/path/baz.json",
                 "--start",
-                "20191020",
+                "2019-10-20",
                 "--end",
-                "20191120",
+                "2019-11-20",
             ]
         )
         mock_read.assert_called_once_with(
@@ -144,9 +191,9 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "https://github.com/foo/bar",
                 "my/path/baz.json",
                 "--start",
-                "20191120",
+                "2019-11-20",
                 "--end",
-                "20191120",
+                "2019-11-20",
             ]
         )
         mock_read.assert_called_once_with(
@@ -166,9 +213,9 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "https://github.com/foo/bar",
                 "my/path/baz.json",
                 "--start",
-                "20191120",
+                "2019-11-20",
                 "--end",
-                "20191020",
+                "2019-10-20",
             ]
         )
         mock_read.assert_not_called()
@@ -184,7 +231,7 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "https://github.com/foo/bar",
                 "my/path/baz.json",
                 "--start",
-                (datetime.today() + timedelta(days=1)).strftime("%Y%m%d"),
+                (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
             ]
         )
         mock_read.assert_not_called()
@@ -202,7 +249,7 @@ class TestHarvestCLICollate(unittest.TestCase):
                 "--start",
                 "20191120",
                 "--end",
-                (datetime.today() + timedelta(days=1)).strftime("%Y%m%d"),
+                (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
             ]
         )
         mock_read.assert_not_called()


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Make `--start` and `--end` options in collate accept humna readable dates, ie 2022-09-29 instead of 20220929
- Enable collation of mulitple files with a single collate command by using `,` as a path seperator.

## Why

The current `--start` and `--end` formats are hard for humans to read, which makes collating data to provide to auditors difficult, as conversion between date formats needs to be done by hand, and the number grouping makes it hard to ensure there have not been any typos etc

Being able to pull multiple files at once makes it easier to pull multiple files over the same date range when an auditor is requesting multiple files.

## How

- Replace all references to `YYYYMMDD` dates to `YYYY-MM-DD` dates
- Split the file path string and iterate over the result calling collate functions multiple times.

## Test

- Updated tests for the new date format
- Add a new test to pull multiple files.

## Context

