### PR TITLE
Make repo branch configurable

### DIFF
--- a/harvest/__init__.py
+++ b/harvest/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The Auditree file collating and reporting tool."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/harvest/cli.py
+++ b/harvest/cli.py
@@ -45,6 +45,14 @@ class _CoreHarvestCommand(Command):
             ),
         )
         self.add_argument(
+            "--branch",
+            help=(
+                "which branch you wish to retrieve git repo evidence from - "
+                "default is master"
+            ),
+            default="master",
+        )
+        self.add_argument(
             "--repo-path",
             help=(
                 "the operating system location of a local git repository - "
@@ -140,7 +148,7 @@ class Collate(_CoreHarvestCommand):
         collator = Collator(
             args.repo,
             Config(args.creds) if args.creds else None,
-            "master",
+            args.branch,
             args.repo_path,
             args.no_validate,
             include_file_path=args.include_file_path,
@@ -196,7 +204,7 @@ class Report(_CoreHarvestCommand):
         reporter = self.report(
             args.repo,
             Config(args.creds) if args.creds else None,
-            "master",
+            args.branch,
             args.repo_path,
             self.template_dir,
             args.no_validate,


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

We want to add an option to the CLI to allow for users to override the branch of their local repo when retrieving files or generating reports based on file content.

## Why

Evidence repo default branch is `main`, harvest tool should collect evidence from main branch.

## How

_Provide a bulleted list of the changes included in the pull request._

## Test

run `make test`

## Context

_Provide a bulleted list of GitHub issues, or any other references (mailing list discussion, etc...) that reviewers can reference
for additional information regarding scope of the pull request._
